### PR TITLE
Suggestion on solving issue where current app steals key presses

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -720,6 +720,7 @@ static void savePrefs() {
 	%orig;
 
 	if(arg2) {
+		[[UIApplication sharedApplication].windows[2] becomeKeyWindow];
 		[[%c(SBSearchViewController) sharedInstance] forceRotation];
 		//UINavigationController *nav = MSHookIvar<UINavigationController *>([%c(SBSearchViewController) sharedInstance], "_navigationController");
 		[[%c(SBSearchViewController) sharedInstance] setHeaderBackground];


### PR DESCRIPTION
I got your PM about the current app receiving keystrokes instead of SpringBoard. I think that the problem may be that the SBAppWindow (Second window of SpringBoard) is not the key window, instead the current application's window is. 

I haven't tested this yet, this is just a suggestion. If this does end up working, make sure that you also make the SBAppWindow resign being the key window when Searchlight is closed. Hope that this helps!
